### PR TITLE
chore: pin pnpm version for deterministic server builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "octahedron-world",
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "predev": "pnpm content && pnpm imagine",
     "dev": "pnpm watch:content & vinxi dev --port 4242",


### PR DESCRIPTION
**What**: Adds `"packageManager": "pnpm@10.33.0"` to `package.json`.

**Why**: The server deploy failed at `pnpm install --frozen-lockfile` with `ERR_PNPM_IGNORED_BUILDS`, listing every native dependency (`sharp`, `esbuild`, `@parcel/watcher`, `protobufjs`, `@firebase/util`) as ignored — even ones already present in `pnpm-workspace.yaml`'s `onlyBuiltDependencies`. Root cause: `package.json` had no `packageManager` field, so `corepack enable pnpm` on the server resolved a different (older) pnpm than the local 10.33.0. Older pnpm reads `onlyBuiltDependencies` from `package.json`, not `pnpm-workspace.yaml`, so it ignored the allowlist entirely and blocked all build scripts.

**How**: Pinning `packageManager` makes corepack use the same pnpm (10.33.0) on the server as locally, so it honors the existing `pnpm-workspace.yaml` config. The lockfile is unaffected (`packageManager` does not change resolution).

**Testing**: `pnpm install --frozen-lockfile` with pnpm 10.33.0 runs clean locally — lockfile in sync, no `ERR_PNPM_IGNORED_BUILDS`. Final confirmation is the next server deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)