### PR TITLE
chore: override protobufjs and fast-xml-parser to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  protobufjs: 7.5.5
+  fast-xml-parser: 4.5.4
+
 patchedDependencies:
   html-to-image@1.11.13:
     hash: 19d2e9e964e8b4e8d3956ecd45fe098a40b94d7b8af1084208fa14f1b0527ab0
@@ -2249,8 +2253,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-xml-parser@4.5.3:
-    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+  fast-xml-parser@4.5.4:
+    resolution: {integrity: sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==}
     hasBin: true
 
   fastq@1.20.1:
@@ -3250,8 +3254,8 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   quansync@0.2.11:
@@ -4484,7 +4488,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
       google-gax: 4.6.1
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4510,7 +4514,7 @@ snapshots:
       abort-controller: 3.0.0
       async-retry: 1.3.3
       duplexify: 4.1.3
-      fast-xml-parser: 4.5.3
+      fast-xml-parser: 4.5.4
       gaxios: 6.7.1
       google-auth-library: 9.15.1
       html-entities: 2.6.0
@@ -4534,7 +4538,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
     optional: true
 
@@ -4542,7 +4546,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
     optional: true
 
@@ -5916,7 +5920,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-xml-parser@4.5.3:
+  fast-xml-parser@4.5.4:
     dependencies:
       strnum: 1.1.2
     optional: true
@@ -6102,7 +6106,7 @@ snapshots:
       node-fetch: 2.7.0
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       retry-request: 7.0.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -7335,10 +7339,10 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
     optional: true
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,10 @@ onlyBuiltDependencies:
 
 patchedDependencies:
   html-to-image@1.11.13: patches/html-to-image@1.11.13.patch
+
+# Security overrides — patched transitive deps of firebase-admin.
+# protobufjs: CVE-2026-41242 (arbitrary code execution)
+# fast-xml-parser: CVE-2026-25896 (entity-encoding bypass)
+overrides:
+  protobufjs: 7.5.5
+  fast-xml-parser: 4.5.4


### PR DESCRIPTION
**What**: Adds `overrides` to `pnpm-workspace.yaml` pinning `protobufjs` to `7.5.5` and `fast-xml-parser` to `4.5.4`, and refreshes `pnpm-lock.yaml`.

**Why**: Both packages had open **critical** Dependabot alerts:
- `protobufjs` < 7.5.5 — CVE-2026-41242, arbitrary code execution ([GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg))
- `fast-xml-parser` < 4.5.4 — CVE-2026-25896, entity-encoding bypass via regex injection ([GHSA-m7jm-9gc2-mpf2](https://github.com/advisories/GHSA-m7jm-9gc2-mpf2))

Both are transitive deps of `firebase-admin@13.6.0` (`protobufjs` via `@google-cloud/firestore`, `fast-xml-parser` via `@google-cloud/storage`).

**How**: The patched versions satisfy the semver ranges the parent packages already declare, so a transitive `overrides` resolves both without upgrading `firebase-admin`. Pinned exact versions per request.

**Testing**: `pnpm install` resolves cleanly; `pnpm why` confirms `protobufjs@7.5.5` and `fast-xml-parser@4.5.4` as the only versions in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)