### PR TITLE
feat: multi-site architecture — one app, two domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "predev": "pnpm content && pnpm imagine",
-    "dev": "pnpm watch:content & vinxi dev --port 4242",
+    "dev": "tsx ./scripts/dev.ts",
     "prebuild": "pnpm content && pnpm imagine",
     "build": "vinxi build",
     "start": "vinxi start",

--- a/scripts/content.ts
+++ b/scripts/content.ts
@@ -1,11 +1,23 @@
 import { readFile, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative, sep } from "node:path";
 import { promisify } from "node:util";
 import { glob } from "glob";
 import { parse } from "hast-mds";
+import type { Site } from "~/site/context";
 import type { ItemMeta } from "~/types";
 
 const read = promisify(readFile);
+
+function deriveSite(file: string, explicit: unknown): Site {
+  // An explicit `site:` key in the MDS global scope overrides the folder rule.
+  if (explicit === "mreis" || explicit === "octahedron") {
+    return explicit;
+  }
+  const rel = relative(join(process.cwd(), "_content"), file);
+  return rel === "mreis" || rel.startsWith(`mreis${sep}`)
+    ? "mreis"
+    : "octahedron";
+}
 
 async function getMetaData(): Promise<Record<string, ItemMeta>> {
   const metaData = {} as Record<string, ItemMeta>;
@@ -46,13 +58,21 @@ async function getMetaData(): Promise<Record<string, ItemMeta>> {
 
     const meta: ItemMeta = {
       ...(result.global as any),
+      site: deriveSite(file, (result.global as any).site),
       mds: result,
     };
 
     if (meta.title) {
+      const existing = metaData[meta.slug];
+      if (existing && existing.site !== meta.site) {
+        console.error(
+          `[CON] ❌ cross-site slug collision: "${meta.slug}" exists for ${existing.site}, skipping ${meta.site} entry from ${file}`,
+        );
+        continue;
+      }
       metaData[meta.slug] = meta;
       console.log(
-        `[CON] 📄 <${meta.type || "default"}> ${meta.slug} | ${meta.title}`,
+        `[CON] 📄 <${meta.type || "default"}> [${meta.site}] ${meta.slug} | ${meta.title}`,
       );
     }
   }
@@ -67,10 +87,10 @@ async function run() {
   const json = JSON.stringify(metadata, null, 2);
   writeFileSync(join(process.cwd(), "data.json"), json);
 
-  // Write routes.json - array of route objects with slug only (all are MDS now)
+  // Write routes.json - array of route objects with slug + site (all are MDS now)
   const routes = Object.entries(metadata)
     .filter(([_, item]) => item.type !== "none")
-    .map(([slug]) => ({ slug }));
+    .map(([slug, item]) => ({ slug, site: item.site }));
   const routesJson = JSON.stringify(routes, null, 2);
   writeFileSync(join(process.cwd(), "routes.json"), routesJson);
   console.log(`[CON] 🗺️  generated ${routes.length} routes`);

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,58 @@
+import { type ChildProcess, spawn } from "node:child_process";
+
+// Dev runner: spawns the content watcher and the vinxi dev server, pipes
+// their output through, and prints clickable URLs for both sites once the
+// server is ready.
+
+const children: ChildProcess[] = [];
+let bannerPrinted = false;
+
+function printBanner() {
+  if (bannerPrinted) return;
+  bannerPrinted = true;
+  console.log("");
+  console.log("  ➜ octahedron  http://octa.localhost:4242/");
+  console.log("  ➜ mreis       http://mreis.localhost:4242/");
+  console.log("");
+}
+
+function shutdown(code: number) {
+  for (const child of children) {
+    if (child.exitCode === null && !child.killed) {
+      child.kill("SIGINT");
+    }
+  }
+  process.exit(code);
+}
+
+const watcher = spawn("pnpm", ["watch:content"], {
+  stdio: "inherit",
+});
+children.push(watcher);
+
+const vinxi = spawn("pnpm", ["exec", "vinxi", "dev", "--port", "4242"], {
+  stdio: ["inherit", "pipe", "inherit"],
+});
+children.push(vinxi);
+
+vinxi.stdout?.on("data", (chunk: Buffer) => {
+  const text = chunk.toString();
+  process.stdout.write(text);
+  // vinxi/vite prints a "Local:" line once the dev server is up.
+  if (!bannerPrinted && text.includes("Local:")) {
+    printBanner();
+  }
+});
+
+// Fallback in case the ready line never matches.
+const fallbackTimer = setTimeout(printBanner, 5000);
+fallbackTimer.unref?.();
+
+for (const child of children) {
+  child.on("exit", (code) => {
+    shutdown(code ?? 0);
+  });
+}
+
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,14 +11,23 @@ import routes from "../routes.json";
 import { Footer } from "./components/footer";
 import { MdsTemplate } from "./components/mds-template";
 import { I18nProvider } from "./i18n/context";
+import { getSite } from "./site/context";
 import { colorSpace, setColorSpace } from "./store/color-space";
 
 export default function App() {
+  const site = getSite();
+  const siteRoutes = routes.filter((r) => (r.site ?? "octahedron") === site);
+
   return (
     <MetaProvider>
       <I18nProvider>
         <Router
           root={(props) => {
+            if (site === "mreis") {
+              // Bare shell for mreis — no octa chrome.
+              return <Suspense>{props.children}</Suspense>;
+            }
+
             const location = useLocation();
             createEffect(() => {
               // Set colorSpace based on pathname to avoid flicker from a
@@ -43,7 +52,7 @@ export default function App() {
             );
           }}
         >
-          <For each={routes}>
+          <For each={siteRoutes}>
             {(route) => (
               <Route
                 path={`/${route.slug}`}

--- a/src/components/mreis/home.tsx
+++ b/src/components/mreis/home.tsx
@@ -1,0 +1,11 @@
+import { Title } from "@solidjs/meta";
+
+export function MreisHome() {
+  return (
+    <main class="mx-auto max-w-2xl px-6 py-16 font-sans">
+      <Title>mreis.me</Title>
+      <h1 class="text-4xl font-bold">mreis.me</h1>
+      <p class="mt-4">Personal site of Matthias Reis — content coming soon.</p>
+    </main>
+  );
+}

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1,4 +1,5 @@
 import { query } from "@solidjs/router";
+import { getSite } from "~/site/context";
 import type { CompactItemMeta, ItemMeta } from "~/types";
 
 let cachedData: Record<string, ItemMeta> | null = null;
@@ -23,7 +24,11 @@ async function getData() {
 export const getRoute = query(async (slug: string) => {
   "use server";
   const data = await getData();
-  return data[slug] || null;
+  const item = data[slug];
+  if (!item || (item.site ?? "octahedron") !== getSite()) {
+    return null;
+  }
+  return item;
 }, "route");
 
 export async function getRedirect(slug: string) {
@@ -48,28 +53,17 @@ export const getAllCompactRoutes: () => Promise<
 > = query(async () => {
   "use server";
   const data = await getData();
+  const site = getSite();
 
   return Object.fromEntries(
-    Object.entries(data).map(
-      ([
-        _key,
-        {
-          slug,
-          title,
-          group,
-          type,
-          image,
-          description,
-          superTitle,
-          subTitle,
-          date,
-          weight,
-        },
-      ]) => {
-        return [
-          slug,
+    Object.entries(data)
+      .filter(([_key, item]) => (item.site ?? "octahedron") === site)
+      .map(
+        ([
+          _key,
           {
             slug,
+            site: itemSite,
             title,
             group,
             type,
@@ -80,25 +74,45 @@ export const getAllCompactRoutes: () => Promise<
             date,
             weight,
           },
-        ];
-      },
-    ),
+        ]) => {
+          return [
+            slug,
+            {
+              slug,
+              site: itemSite,
+              title,
+              group,
+              type,
+              image,
+              description,
+              superTitle,
+              subTitle,
+              date,
+              weight,
+            },
+          ];
+        },
+      ),
   );
 }, "all-routes-overview");
 
 export const getAllRootRoutes = query(async () => {
   "use server";
   const data = await getData();
+  const site = getSite();
 
   const availableItems = Object.values(data)
-    .filter((item) => item.root)
-    .map(({ slug, title, image, description, group, weight }) => ({
-      slug,
-      title,
-      group,
-      image,
-      description,
-      weight: weight ?? 0,
-    }));
+    .filter((item) => item.root && (item.site ?? "octahedron") === site)
+    .map(
+      ({ slug, site: itemSite, title, image, description, group, weight }) => ({
+        slug,
+        site: itemSite,
+        title,
+        group,
+        image,
+        description,
+        weight: weight ?? 0,
+      }),
+    );
   return availableItems as CompactItemMeta[];
 }, "all-root-routes");

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,13 +3,19 @@ import { For } from "solid-js";
 import { cx } from "~/components/cx";
 import { Head } from "~/components/head";
 import { largeImageUrl, smallImageUrl } from "~/components/image-helpers";
+import { MreisHome } from "~/components/mreis/home";
 import OctahedronLogo from "~/components/octahedron-logo";
 import { useI18n } from "~/i18n/context";
 import { sortRootItems } from "~/model/helpers";
 import { getAllRootRoutes } from "~/model/model";
+import { getSite } from "~/site/context";
 import type { CompactItemMeta } from "~/types";
 
 export default function HomePage() {
+  if (getSite() === "mreis") {
+    return <MreisHome />;
+  }
+
   const getItems = createAsyncStore(() => getAllRootRoutes());
   const { t } = useI18n();
 

--- a/src/site/context.ts
+++ b/src/site/context.ts
@@ -1,0 +1,17 @@
+import { getRequestEvent, isServer } from "solid-js/web";
+
+export type Site = "octahedron" | "mreis";
+
+const MREIS_HOSTNAMES = new Set(["mreis.me", "mreis.localhost"]);
+
+export function getSite(): Site {
+  const host = isServer
+    ? (getRequestEvent()?.request.headers.get("host") ?? "")
+    : window.location.host;
+
+  const hostname = host.split(":")[0].replace(/^www\./, "");
+
+  // Explicit allowlist for mreis; octahedron is the default for any other
+  // hostname so the existing site never breaks from an unrecognized host.
+  return MREIS_HOSTNAMES.has(hostname) ? "mreis" : "octahedron";
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 import type { HastParseResult } from "hast-mds";
 import type { Options } from "hast-util-to-jsx-runtime";
+import type { Site } from "./site/context";
 
 export type ItemMeta = {
   slug: string; // new url ${group}/${slug} - when slug = group then it's a root entry
+  site: Site; // which site serves this item; derived from _content/ subfolder, overridable via explicit `site:` key
   alias?: string; // old url
   group: string; // new grouping. E.g. 'hermetics'
   type?: string; // MDS renderer type
@@ -38,6 +40,7 @@ export type LocalScope = Record<string, never>;
 export type CompactItemMeta = Pick<
   ItemMeta,
   | "slug"
+  | "site"
   | "title"
   | "group"
   | "type"


### PR DESCRIPTION
## What

The codebase now serves two sites, branched at runtime by hostname:

- **octahedron** (default) — every hostname not on the mreis allowlist serves the existing site unchanged
- **mreis** — `mreis.me` / `mreis.localhost` serve a new, bare placeholder site

## How

- `src/site/context.ts` — `Site` type + `getSite()`: server reads the `Host` header via `getRequestEvent()`, client reads `window.location.host`; port and `www.` stripped; explicit allowlist for mreis, octahedron as the safe default.
- **Content pipeline** (`scripts/content.ts`) stamps `site` on every item, derived from a new top-level `_content/mreis/` folder (an explicit `site:` key in the MDS global scope overrides). `routes.json` entries are now `{slug, site}`. Cross-site slug collisions log an error and skip.
- `src/app.tsx` filters MDS routes by site; the router root renders the octa chrome (Nav/Footer/colorSpace) only for octahedron and a bare shell for mreis.
- `src/model/model.ts` — `getRoute` / `getAllCompactRoutes` / `getAllRootRoutes` filter by site inside the server functions, so a direct URL on one host can never serve the other site's content.
- `src/routes/index.tsx` branches to a placeholder mreis homepage (`src/components/mreis/home.tsx`).
- `scripts/dev.ts` replaces the inline dev command: spawns `watch:content` + `vinxi dev --port 4242`, tears both down on SIGINT, and prints once ready:

  ```
    ➜ octahedron  http://octa.localhost:4242/
    ➜ mreis       http://mreis.localhost:4242/
  ```

## Verified

- `pnpm build` passes; biome check clean on all touched files; no new tsc errors in touched files.
- Dev server: both URLs printed; `octa.localhost:4242` serves the existing homepage, MDS route (`/world-2-energy`), and redirect (`/storylines/world-2` → 302) unchanged; `mreis.localhost:4242` serves the placeholder; an octahedron slug on the mreis host renders Not Found (the catch-all's existing HTTP-200-with-404-page behavior, unchanged by this PR).

## Out of scope

Prod domain wiring (Coolify/DNS), migrating mreis.me content, analytics, per-site theming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Le4BdgBtdAgStBtUDSdvCc