### PR TITLE
chore: retire Octa workflow docs and dead dependencies

### DIFF
--- a/.claude/skills/pcsc-task/SKILL.md
+++ b/.claude/skills/pcsc-task/SKILL.md
@@ -21,7 +21,8 @@ documentation:** `src/pcsc/CLAUDE.md` (read this for PCSC-specific architecture)
 ## Guidelines
 
 1. Check `src/pcsc/CLAUDE.md` for PCSC-specific context before starting
-2. Reference `CLAUDE.md` for Octahedron patterns (layouts, plugins, data layer)
+2. Reference `CLAUDE.md` for Octahedron patterns (MDS content, renderers, data
+   layer)
 3. Look at original code in `../pcsc` when needed to understand existing
    implementation
 4. Update `src/pcsc/CLAUDE.md` with any architectural decisions or new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,25 +6,27 @@ A personal content publishing platform built with SolidStart and Tailwind CSS.
 
 - **Framework**: SolidStart 1.1+ (meta-framework for SolidJS)
 - **Styling**: Tailwind CSS 4.0+
-- **Routing**: SolidJS Router (file-based routing)
+- **Routing**: SolidJS Router (file-based routes + routes generated from content)
 - **Build Tool**: Vinxi
-- **Content**: Markdown files with YAML frontmatter or solid-mds format
+- **Content**: Markdown in MDS format (`hast-mds` on the build side, `solid-mds`
+  in the renderers)
 - **Images**: Sharp for processing
 
 ## Project Structure
 
 ```
 octahedron.world/
-├── _content/              # Markdown content files organized by topic
+├── _content/              # Markdown content files organized by group
 ├── src/
-│   ├── routes/           # SolidStart file-based routes
+│   ├── routes/           # SolidStart file-based routes (hand-written pages)
 │   ├── components/       # Reusable UI components
-│   │   ├── layouts/      # Layout components for different content types
-│   │   └── plugins/      # Content section renderers
-│   ├── model/            # Data access layer
+│   │   └── mds-template.tsx  # Maps an item's `type` to its renderer
+│   ├── renderers/        # One full-page renderer per content type
+│   ├── model/            # Data access layer (reads data.json)
+│   ├── sites/            # Per-site shells (octahedron, mreis)
 │   └── types.ts          # TypeScript type definitions
 ├── scripts/
-│   ├── content.ts        # Parses markdown and generates data.json
+│   ├── content.ts        # Parses MDS markdown and generates the JSON files
 │   ├── imagine.ts        # Processes images for web
 │   └── watch-content.ts  # Watches content changes in dev mode
 ├── public/
@@ -36,132 +38,107 @@ octahedron.world/
 
 ## Content System
 
-The content system supports two distinct workflows for processing and rendering content:
+There is exactly **one** content workflow: MDS. Every file in `_content/` is an
+MDS document, and every published page is rendered by a renderer in
+`src/renderers/`. There is no frontmatter workflow, no layouts and no plugins —
+those were removed in early 2026.
 
-1.  **Octa Workflow** (Legacy): Uses YAML frontmatter and Layouts.
-2.  **MDS Workflow** (New): Uses `solid-mds` parsing and Renderers.
+### The pipeline
 
-Both workflows coexist. The file format is detected automatically by `scripts/content.ts`.
-
-### 1. Octa Workflow (Frontmatter + Layouts)
-
-**File Format**: Standard markdown starting with `---` (YAML frontmatter).
-**Behavior**:
--   Parses YAML frontmatter for metadata.
--   Splits body into sections (text, custom plugins).
--   Uses **Layouts** in `src/components/layouts/` to render the page.
-
-**Structure**:
-```yaml
----
-workflow: octa # (Implicit)
-slug: my-octa-page
-layout: post # Selects src/components/layouts/post
----
+```
+_content/**/*.md
+   │   scripts/content.ts  (pnpm content)
+   ▼
+data.json  +  routes.json  +  redirects.json
+   │   src/app.tsx reads routes.json and creates a <Route> per entry
+   ▼
+MdsTemplate (src/components/mds-template.tsx)
+   │   looks up renderers[item.type]
+   ▼
+src/renderers/{type}
 ```
 
-### 2. MDS Workflow (solid-mds + Renderers)
+`src/model/model.ts` is the only thing that reads `data.json`; renderers receive
+the already-parsed MDS structure.
 
-**File Format**: Markdown starting with backticks ` ``` ` (solid-mds format).
-**Behavior**:
--   Parses using `solid-mds` package.
--   Extracts **Global Metadata** (`@@|`) for `data.json`.
--   Uses **Renderers** in `src/renderers/` to render the page.
--   The renderer is chosen by the `type` field in global metadata (defaults to `default` or `dica` depending on context).
+### File format
 
-**Structure**:
+An MDS file starts with a **global scope** — a fenced YAML block marked `@@`.
+It is mandatory: `pnpm content` aborts on a file that does not have one.
+
 ````markdown
-```@@|
-slug: my-mds-page
-type: dica     # Selects src/renderers/dica
-title: My Title
+```yaml @@
+slug: my-page
+group: my-group
+title: My Page Title
+type: post
+image: my-image
 ```
+
+# Heading
+
+Regular markdown content.
 ````
 
-**Syntax specific to this project**:
--   **Global Metadata** (`@@|`): Equivalent to frontmatter. Must be at the start.
--   **Steps** (`+++step-id`): Divides content into interactive steps/slides.
--   **Local Metadata** (`@|`): Per-step configuration.
--   **Custom Blocks** (`:::variant`): Special components (like Quests).
+The fence is ` ```yaml @@ ` — that is the only accepted form.
+
+### Syntax specific to this project
+
+- **Global scope** (` ```yaml @@ `): page metadata, must be the first thing in
+  the file. Feeds `data.json`.
+- **Steps** (`+++step-id`): divides a document into named steps/slides. Used by
+  the step-based renderers (`dica`, `storyline`).
+- **Local scope** (` ```yaml @ `): per-step configuration, placed directly under
+  a `+++` marker.
+- **Custom blocks** (` ```yaml <name> `): a fenced YAML block rendered by a
+  registered component instead of as code — e.g. ` ```yaml teaser `. The block
+  names known to the parser are listed in `scripts/content.ts`; the components
+  they map to live in `src/components/canonical-components.tsx`.
+
+### Required metadata
+
+`slug`, `title` and `image` are effectively mandatory (see `ItemMeta` in
+`src/types.ts`). A missing `title` aborts `pnpm content` — the page is not
+silently dropped.
 
 ## Renderers
 
-The `src/renderers/` directory contains full-page applications/templates for MDS content.
+`src/renderers/` holds one full-page renderer per content type. The renderer is
+selected by the `type` field in the global scope and wired up in the `renderers`
+map in `src/components/mds-template.tsx`.
 
--   **Path**: `src/renderers/{type}/create-template.tsx` (pattern may vary)
--   **Integration**: Loaded by `src/components/mds-template.tsx` based on the `type` field.
--   **Example**: `src/renderers/dica` is a comprehensive interactive renderer with state management, progress tracking, and a quest system.
+Registered types:
 
-## Layouts and Plugins (Octa Workflow)
+| `type`                  | renderer                              |
+| ----------------------- | ------------------------------------- |
+| `post`                  | `src/renderers/default`               |
+| `default`               | `src/renderers/default`               |
+| `album`                 | `src/renderers/album`                 |
+| `dica`                  | `src/renderers/dica`                  |
+| `digest`                | `src/renderers/digest`                |
+| `grid`                  | `src/renderers/grid`                  |
+| `legal`                 | `src/renderers/legal`                 |
+| `lightbox`              | `src/renderers/lightbox`              |
+| `population-simulation` | `src/renderers/population-simulation` |
+| `report`                | `src/renderers/report`                |
+| `storyline`             | `src/renderers/storyline`             |
+| `world2`                | `src/renderers/world2`                |
 
-### Layouts
+An unknown `type` renders a visible "Unknown renderer type" fallback rather than
+failing the build.
 
-Layouts define how content is displayed for the **Octa** workflow. Located in
-[src/components/layouts/](src/components/layouts/).
+**`type: none`** is not a renderer. It marks a page that belongs in `data.json`
+(so its metadata stays queryable) but must _not_ get a generated route —
+`content.ts` filters it out of `routes.json`. It is used by `pcsc-one` and
+`pcsc-contest`, which own hand-written file routes in `src/routes/`.
 
-Each layout provides:
+### Creating a new renderer
 
-- **Main component**: Overall page structure (header, container, styling)
-- **Section wrapper**: How to wrap each content section
-- **Plugins**: Custom renderers for special content types
-
-The `layout` field in frontmatter selects which layout to use. If omitted,
-`default` layout is used.
-
-### Plugins System
-
-Plugins are responsible for rendering individual content sections in the **Octa** workflow. The
-`pnpm content` script parses markdown files and creates a list of sections,
-where each section has a `type` and a `payload`.
-
-**How it works:**
-
-1. **Content parsing** ([scripts/content.ts](scripts/content.ts)):
-   - Markdown body is split into sections by `---` delimiters
-   - Plain text becomes `{ type: 'text', payload: '...' }`
-   - Special syntax `==> slug` becomes `{ type: 'link', payload: 'slug' }`
-   - Custom syntax `==> <type> payload` becomes
-     `{ type: 'type', payload: 'payload' }`
-
-2. **Section rendering** ([src/components/octa.tsx](src/components/octa.tsx)):
-   - For each section, looks up the plugin for that section's `type`
-   - If layout defines a plugin for that type, uses it
-   - Otherwise falls back to `DefaultPlugin` (shows error state)
-
-3. **Plugin interface**:
-
-   ```typescript
-   type Plugin = (props: {
-     type: string;
-     payload: string;
-     wrapper?: ParentComponent;
-   }) => JSX.Element;
-   ```
-
-**Built-in plugins** ([src/components/plugins/](src/components/plugins/)):
-
-- **`text`**: Default plugin that transforms markdown to HTML using
-  remark/rehype
-  - Handles all standard markdown syntax
-  - Can be customized per-layout with different component mappings
-  - Example: Headers, paragraphs, lists, code blocks, math (KaTeX)
-- **`link`**: Renders a link box to another page by slug
-  - Payload is a slug reference (e.g., `mesh`)
-  - Fetches metadata and displays as a card with image and description
-- **`group`**: Displays all pages within a content group
-- **`cta`**: Call-to-action component
-- **`world-2-calculator`**: Custom interactive calculator (example of special
-  functionality)
-- **`default`**: Fallback plugin that shows error for unknown types
-
-**Extensibility:**
-
-The plugin system is designed for future expansion. To add new section types:
-
-1. Create a new plugin in `src/components/plugins/{name}/index.tsx`
-2. Register it in the layout's plugin map
-3. Use the custom syntax in markdown: `==> <{name}> {payload}`
-
+1. Create `src/renderers/{name}/index.tsx` (plus a `types.ts` for its
+   `GlobalScope`/`LocalScope` if it needs one).
+2. Default-export a component taking the parsed MDS structure.
+3. Register the key in the `renderers` map in
+   `src/components/mds-template.tsx`.
 
 ## Data Layer (Model)
 
@@ -192,114 +169,53 @@ name `model` follows MVC-like conventions and is concise.
 
 ### Adding a New Content Page
 
-```bash
-# 1. Create markdown file
-# File: _content/my-group/my-page.md
----
+Create the file — `_content/my-group/my-page.md`:
+
+````markdown
+```yaml @@
 slug: my-page
-title: My Page Title
 group: my-group
-layout: post
+title: My Page Title
+type: post
 image: my-image
----
-
-This is my content.
-
-==> related-page
-
-More content here.
+description: What this page is about
 ```
 
-```bash
-# 2. Add image (same directory as markdown)
-# _content/my-group/my-image.jpg
+This is my content.
+````
 
-# 3. Process content
+Then:
+
+```bash
+# 1. Add the image next to the markdown file
+#    _content/my-group/my-image.jpg
+
+# 2. Process content and images
 pnpm content && pnpm imagine
 
-# 4. Verify in data.json
-# Check that my-page appears with correct metadata
+# 3. Verify in data.json that my-page appears with correct metadata
 ```
 
 ### Creating a Root Item (Homepage Entry)
 
-Add to existing content's frontmatter:
+Add to the page's global scope:
 
 ```yaml
 root: true
-weight: 5 # Lower numbers appear first
+weight: 5 # controls sort order
 description: Brief description shown on homepage
 ```
 
-### Linking Between Pages in Markdown
+### Linking Between Pages
 
-Use the link plugin syntax:
+Use ordinary markdown links, or a teaser block to render a card with the target
+page's image and metadata:
 
-```markdown
-Some paragraph of text.
-
-==> other-page-slug
-
-More content continues here.
+````markdown
+```yaml teaser
+slug: other-page-slug
 ```
-
-This renders as a styled link box with image and metadata.
-
-### Using Custom Section Types
-
-```markdown
-Regular markdown content here.
-
-==> <cta> https://example.com
-
-More markdown content.
-
-==> <world-2-calculator> config-data
-
-Text continues.
-```
-
-Each `==> <type> payload` creates a section with that type, rendered by the
-corresponding plugin.
-
-### Creating a New Plugin
-
-1. **Create plugin file**:
-
-   ```typescript
-   // src/components/plugins/my-plugin/index.tsx
-   import { Plugin } from '~/types';
-
-   export const MyPlugin: Plugin = ({ type, payload, wrapper }) => {
-     const Wrapper = wrapper || 'section';
-     return (
-       <Wrapper>
-         <div>Custom rendering for: {payload}</div>
-       </Wrapper>
-     );
-   };
-   ```
-
-2. **Register in layout**:
-
-   ```typescript
-   // src/components/layouts/my-layout/index.ts
-   import { MyPlugin } from '~/components/plugins/my-plugin';
-
-   export const myLayout = {
-     main: MyLayoutMain,
-     plugins: {
-       text: TextPlugin(),
-       link: LinkPlugin,
-       'my-plugin': MyPlugin, // Register here
-     },
-   };
-   ```
-
-3. **Use in markdown**:
-   ```markdown
-   ==> <my-plugin> some-payload-data
-   ```
+````
 
 ### Querying Data in Components
 
@@ -336,8 +252,8 @@ pnpm start        # Run production server
 
 ### Working with Content
 
-1. **Add new content**: Create `.md` file in `_content/{group}/` with proper
-   frontmatter
+1. **Add new content**: Create a `.md` file in `_content/{group}/` with a
+   ` ```yaml @@ ` global scope
 2. **Add images**: Place images in same directory as markdown file
 3. **Run scripts**: `pnpm content && pnpm imagine` (or restart dev server)
 4. **Check data.json**: Verify your content appears with correct metadata
@@ -346,16 +262,19 @@ pnpm start        # Run production server
 
 To show a page on the homepage:
 
-1. Add `root: true` to frontmatter
-2. Add `weight: N` to control sort order (higher numbers appear first)
+1. Add `root: true` to the global scope
+2. Add `weight: N` to control sort order
 3. Ensure `image` field points to an existing image
 
 ## Important Notes
 
 - **Never edit generated files**: `data.json`, `routes.json`, `redirects.json`
-  are auto-generated
-- **Image references**: Use filename without extension in frontmatter (e.g.,
-  `image: mesh` for `mesh.jpg`)
+  are auto-generated (and gitignored)
+- **Image references**: Use the filename without extension (e.g. `image: mesh`
+  for `mesh.jpg`)
 - **Slug uniqueness**: Each slug must be unique across all content
-- **Layout selection**: Layout determines the entire page structure and
-  available content section types
+- **Malformed content fails the build**: a file without a ` ```yaml @@ ` global
+  scope, or without a `title`, aborts `pnpm content`. Pages are never silently
+  dropped.
+- **Type selection**: `type` determines the entire page structure and which
+  custom blocks make sense

--- a/README.md
+++ b/README.md
@@ -6,48 +6,60 @@ Data System) workflow.
 ## Architecture
 
 This project uses a **pure MDS workflow** for all content. MDS allows markdown
-files to define their own rendering behavior through frontmatter and custom
-components.
+files to define their own rendering behavior through a YAML global scope and
+custom components. There is no second, frontmatter-based workflow.
 
 ### Content System
 
 All content is stored in `_content/` with the following structure:
 
-- **Frontmatter**: Wrapped in ` ```@@|` and ` ``` ` (MDS format)
+- **Global scope**: a fenced YAML block opened with ` ```yaml @@ ` — the only
+  accepted form. Mandatory, and must be the first thing in the file.
 - **Type**: Determines which renderer to use (e.g., `storyline`, `lightbox`,
   `report`, `post`)
 - **Content**: Standard markdown with optional custom components
 
 #### Example Content File
 
-```markdown
-\`\`\`@@| title: My Story type: storyline description: A great story group:
-stories slug: my-story image: my-image \`\`\`
+````markdown
+```yaml @@
+title: My Story
+type: storyline
+description: A great story
+group: stories
+slug: my-story
+image: my-image
+```
 
 # Chapter 1
 
 Content goes here...
-```
+````
 
 ### Renderers
 
-Renderers are located in `src/renderers/` and define how content is displayed:
+Renderers are located in `src/renderers/` and define how content is displayed.
+They are registered by `type` in `src/components/mds-template.tsx`:
 
-- **`storyline`**: For narrative stories with sequential steps
-- **`lightbox`**: For photo galleries and visual content
-- **`report`**: For in-depth articles with structured layout
-- **`world2`**: Extended report with calculator and graphics plugins
 - **`post`/`default`**: Standard blog posts with two-column layout
-- **`entry`**: For index/overview pages
-- **`grid`**: For grid-based layouts
 - **`album`**: For photo albums
 - **`dica`**: Interactive quest-based content
+- **`digest`**: Curated link/summary collections
+- **`grid`**: For grid-based layouts
 - **`legal`**: For legal pages
+- **`lightbox`**: For photo galleries and visual content
+- **`population-simulation`**: Interactive population model
+- **`report`**: For in-depth articles with structured layout
+- **`storyline`**: For narrative stories with sequential steps
+- **`world2`**: Extended report with calculator and graphics blocks
+
+`type: none` is not a renderer — it keeps a page in `data.json` while excluding
+it from `routes.json`, for pages that own a hand-written file route.
 
 Each renderer:
 
 1. Parses markdown using `solid-mds`
-2. Extracts frontmatter (global scope)
+2. Extracts the global scope
 3. Renders content using SolidJS components
 4. Can register custom components via `canonicalComponents`
 
@@ -57,7 +69,8 @@ Each renderer:
 
 Processes all markdown files in `_content/`:
 
-- Parses MDS frontmatter
+- Parses the MDS global scope of every file (and fails the build on a malformed
+  one)
 - Generates `data.json` with all metadata
 - Generates `routes.json` for routing
 - Generates `redirects.json` for URL aliases
@@ -73,7 +86,7 @@ Runs the development server with content watching
 ## Adding New Content
 
 1. Create a markdown file in `_content/[group]/[slug].md`
-2. Add MDS frontmatter with type and metadata
+2. Add a ` ```yaml @@ ` global scope with `type` and metadata
 3. Write content in markdown
 4. Run `pnpm content` to regenerate metadata
 5. The content will be automatically routed

--- a/_content/art/verner-panton-living-sculpture-pompidou.md
+++ b/_content/art/verner-panton-living-sculpture-pompidou.md
@@ -1,5 +1,5 @@
 ```yaml @@
-ttitle: 'Siège Living Sculpture'
+title: 'Siège Living Sculpture'
 description: >-
   An immersive "Pop" furniture environment by Danish designer Verner Panton. 
   Originally conceived for his private residence and later showcased at the 

--- a/package.json
+++ b/package.json
@@ -52,10 +52,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.5",
     "@tailwindcss/vite": "^4.0.7",
-    "@types/js-yaml": "^4.0.9",
     "esbuild": "^0.28.0",
     "glob": "^13.0.0",
-    "js-yaml": "^4.1.1",
     "mkdirp": "^3.0.1",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,18 +113,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.7
         version: 4.1.18(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
       glob:
         specifier: ^13.0.0
         version: 13.0.0
-      js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1621,9 +1615,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
-
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
@@ -1759,9 +1750,6 @@ packages:
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
-
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   arrify@2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
@@ -2670,10 +2658,6 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5253,8 +5237,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/js-yaml@4.0.9': {}
-
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
@@ -5441,8 +5423,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  argparse@2.0.1: {}
 
   arrify@2.0.1:
     optional: true
@@ -6483,10 +6463,6 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   jsesc@3.1.0: {}
 

--- a/scripts/content.ts
+++ b/scripts/content.ts
@@ -32,8 +32,10 @@ async function getMetaData(): Promise<Record<string, ItemMeta>> {
     const trimmed = raw.trimStart();
 
     if (!trimmed.startsWith("```")) {
-      console.log(`[CON] ⚠️  Skipping non-MDS file: ${file}`);
-      continue;
+      console.error(
+        `[CON] ❌ not an MDS file: ${file} — every file in _content/ must open with a \`\`\`yaml @@ global scope`,
+      );
+      process.exit(1);
     }
 
     // Parse with hast-mds (server-side)
@@ -52,8 +54,10 @@ async function getMetaData(): Promise<Record<string, ItemMeta>> {
       ]),
     );
     if (!result.global) {
-      console.log(`[CON] ⚠️  No MDS Global Scope found in: ${file}`);
-      continue;
+      console.error(
+        `[CON] ❌ no MDS global scope in: ${file} — expected a \`\`\`yaml @@ block at the top of the file`,
+      );
+      process.exit(1);
     }
 
     const meta: ItemMeta = {
@@ -62,19 +66,24 @@ async function getMetaData(): Promise<Record<string, ItemMeta>> {
       mds: result,
     };
 
-    if (meta.title) {
-      const existing = metaData[meta.slug];
-      if (existing && existing.site !== meta.site) {
-        console.error(
-          `[CON] ❌ cross-site slug collision: "${meta.slug}" exists for ${existing.site}, skipping ${meta.site} entry from ${file}`,
-        );
-        continue;
-      }
-      metaData[meta.slug] = meta;
-      console.log(
-        `[CON] 📄 <${meta.type || "default"}> [${meta.site}] ${meta.slug} | ${meta.title}`,
+    if (!meta.title) {
+      console.error(
+        `[CON] ❌ missing \`title\` in the global scope of: ${file} — a page without a title cannot be published`,
       );
+      process.exit(1);
     }
+
+    const existing = metaData[meta.slug];
+    if (existing && existing.site !== meta.site) {
+      console.error(
+        `[CON] ❌ cross-site slug collision: "${meta.slug}" exists for ${existing.site}, skipping ${meta.site} entry from ${file}`,
+      );
+      continue;
+    }
+    metaData[meta.slug] = meta;
+    console.log(
+      `[CON] 📄 <${meta.type || "default"}> [${meta.site}] ${meta.slug} | ${meta.title}`,
+    );
   }
   return metaData;
 }
@@ -87,7 +96,9 @@ async function run() {
   const json = JSON.stringify(metadata, null, 2);
   writeFileSync(join(process.cwd(), "data.json"), json);
 
-  // Write routes.json - array of route objects with slug + site (all are MDS now)
+  // Write routes.json - array of route objects with slug + site.
+  // `type: none` keeps an item in data.json but generates no route: those pages
+  // own a hand-written file route in src/routes/.
   const routes = Object.entries(metadata)
     .filter(([_, item]) => item.type !== "none")
     .map(([slug, item]) => ({ slug, site: item.site }));


### PR DESCRIPTION
## Why

The Octa workflow (YAML frontmatter + Layouts + Plugins) was removed from the code in `9daabf8` back in February. The docs never followed. `CLAUDE.md` still described two co-existing workflows, ~130 lines of it documenting `src/components/layouts/`, `src/components/plugins/` and `src/components/octa.tsx` — none of which exist. An agent following it today writes a `---` frontmatter file that `pnpm content` silently discards.

Verified before touching anything: 171/171 files in `_content/` are MDS, zero `layout:` or `workflow:` keys, layouts/plugins directories gone, no CMS, CI unaware. There was nothing left to remove in code — only in docs and `package.json`.

## What changed

**`CLAUDE.md`** — Content System section rewritten around the one real pipeline:

```
content.ts → data.json/routes.json/redirects.json → app.tsx → MdsTemplate → src/renderers/{type}
```

Removed: the "two distinct workflows" framing, the Octa Workflow section, "Layouts and Plugins", the Plugin interface, the built-in plugin list, "Creating a New Plugin", the `==> slug` / `==> <type> payload` syntax, and the `layout:`-frontmatter page example. Directory tree corrected.

**`CLAUDE.md` + `README.md`** — the renderer list now matches the 12 keys actually registered in `mds-template.tsx` (`post`/`default` both resolve to `src/renderers/default`). The `entry` renderer, gone since `66916cf`, is dropped rather than restored. The `type: none` convention (in `data.json`, excluded from `routes.json`, used by `pcsc-one`/`pcsc-contest` which own hand-written file routes) is documented. Every ` ```@@| ` corrected to ` ```yaml @@ ` — the only form any of the 171 real files uses.

**`scripts/content.ts`** — the last remnant of workflow detection was a silent skip. A non-MDS file, a missing global scope, or a missing `title` now `console.error` + `process.exit(1)` naming the file. The missing-`title` case previously produced *no output at all*.

**`_content/art/verner-panton-living-sculpture-pompidou.md`** — `ttitle:` → `title:`. That typo is what the silent skip had been hiding: the page has been absent from `data.json` since 2026-02-06.

**`package.json`** — `js-yaml` and `@types/js-yaml` removed. Zero imports anywhere; leftovers from the frontmatter parser.

## Verification

| | before | after |
| --- | --- | --- |
| `data.json` entries | 170 | **171** |
| `routes.json` routes | 168 | **169** |

- `pnpm build` passes — its `prebuild` runs `pnpm content`, so all 171 files clear the stricter guard.
- Both new failure paths confirmed to exit 1 with a clear message (tested with throwaway files, since removed).
- No `layout` / octa-workflow / `js-yaml` references survive in docs or code. Remaining `layout` hits are `src/ui/footer.tsx` and `src/ui/link-box.tsx` props, plus `font-octa` (a Tailwind font family), all unrelated.

## Noted, not fixed

`_content/general/about.md` and `_content/general/ueber-uns.md` still contain a bare `==> hermetics` line — old link-plugin syntax that now renders as literal text. Replacing it is an editorial call (teaser block? plain link?), so it is left out of this docs/deps PR.